### PR TITLE
Make wait_for_sync async

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,7 +188,7 @@ async def periodic_sync_check():
                 
                 # Attempt resync with progressively longer timeouts based on consecutive failures
                 timeout = min(5 + (_consecutive_sync_failures * 2), 30)  # Increase timeout up to 30 seconds
-                if _payment_handler.wait_for_sync(timeout_seconds=timeout):
+                if await _payment_handler.wait_for_sync(timeout_seconds=timeout):
                     logger.info("SDK resync successful")
                     _last_sync_time = time.time()
                     _consecutive_sync_failures = 0


### PR DESCRIPTION
## Summary
- add async wait_for_sync method
- use async wait_for_sync in periodic_sync_check

## Testing
- `python -m py_compile main.py nodeless.py`

------
https://chatgpt.com/codex/tasks/task_e_684fade4fa20832db8bb877d1f10d411